### PR TITLE
Add support for Go modules

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,12 +51,13 @@ func (imp *imports) Set(s string) error {
 	} else if alias == "" {
 		return fmt.Errorf("%q: empty alias", s)
 	} else if alias == "_" || alias == "." {
-		alias = alias + " " + path // special alias
+		tmpPath, _, _ := strings.Cut(path, "@")
+		alias = alias + " " + tmpPath // special alias
 	} else if strings.Contains(alias, " ") {
 		return fmt.Errorf("%q: invalid alias", s)
 	}
 	var p2 string
-	if p2, version, ok = strings.Cut(s, "@"); ok {
+	if p2, version, ok = strings.Cut(path, "@"); ok {
 		if version == "" {
 			return fmt.Errorf("%q: empty module version", s)
 		}


### PR DESCRIPTION
Add support for Go module mode. This will allow to use strictly specified dependencies.

If at least one versioned path is mentioned in imports (`-i` flag), switch to Go module mode:
* produce a `go.mod` in a temporary directory
* launch `go mod download` to fetch the code (this might produce a `go.sum`)
* find a way to tell `goimports` and `go run` to run in Go module mode using our `go.mod`

Upgraded `-i` syntax to enable Go modules:
* `path` for package import (same as now)
* `alias=path` for package import (same as now)
* `_=path` for `_` package import (multiple now allowed)
* `.=path` for `.` package import (multiple now allowed)
* `path@version` for module import (package import hopefully handled by `goimports`)
* `alias=path@version` for module import + package import + aliasing
