### PR TITLE
Use Go cache if modules are found in the cache

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,7 +249,8 @@ func _main() error {
 		for mod, ver := range imports.modules {
 			gogetArgs = append(gogetArgs, mod+"@"+ver)
 			if preferCache {
-				// Keep preferCache as long as we find modules in the cache
+				// Keep preferCache as long as we find modules in the cache.
+				// Structure of the cache is documented here: https://go.dev/ref/mod#module-cache
 				_, err := os.Stat(gomodcache + "/cache/download/" + mod + "/@v/" + ver + ".mod")
 				preferCache = err == nil
 			}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"golang.org/x/mod/module"
-	"golang.org/x/mod/semver"
 	goimp "golang.org/x/tools/imports"
 )
 
@@ -73,7 +72,7 @@ func (imp *imports) Set(s string) error {
 			imp.modules = make(map[string]string)
 		}
 		imp.modules[path] = version
-		imp.onlySemVer = imp.onlySemVer && semver.IsValid(version) && version == semver.Canonical(version)
+		imp.onlySemVer = imp.onlySemVer && version == module.CanonicalVersion(version)
 	} else if alias == "" {
 		alias = "  " + path // special alias
 	}

--- a/main.go
+++ b/main.go
@@ -264,7 +264,8 @@ func _main() error {
 		if preferCache {
 			// As we found all modules in the cache, tell "go get" and "go run" to not use the proxy.
 			// See https://go.dev/issue/43646
-			env = append(env, "GOPROXY=file://"+filepath.ToSlash(gomodcache)+"/cache/download")
+			// env = append(env, "GOPROXY=file://"+filepath.ToSlash(gomodcache)+"/cache/download")
+			env = append(env, "GOPROXY=off")
 		}
 
 		cmd := exec.Command("go", gogetArgs...)

--- a/main.go
+++ b/main.go
@@ -261,15 +261,14 @@ func _main() error {
 		}
 
 		// fmt.Println("preferCache", preferCache)
+		if preferCache {
+			// As we found all modules in the cache, tell "go get" and "go run" to not use the proxy.
+			// See https://go.dev/issue/43646
+			env = append(env, "GOPROXY=file://"+filepath.ToSlash(gomodcache)+"/cache/download")
+		}
 
 		cmd := exec.Command("go", gogetArgs...)
-		if preferCache {
-			// As we found all modules in the cache, tell "go get" to not use the proxy.
-			// See https://go.dev/issue/43646
-			cmd.Env = append(env, "GOPROXY=file://"+filepath.ToSlash(gomodcache)+"/cache/download")
-		} else {
-			cmd.Env = env
-		}
+		cmd.Env = env
 		cmd.Dir = dir
 		cmd.Stdin = nil
 		cmd.Stdout = nil


### PR DESCRIPTION
`go get` is slow: even if all requested module versions are canonical (`v1.0.0`, not `v1` or `latest`) and are available locally, it still queries the Go proxy. (note: this is good for security as it allows to verify for retracted versions).

So, in module mode, when all module dependencies are given with [canonical versions](https://pkg.go.dev/golang.org/x/mod/module#CanonicalVersion) and the version is found in the cache, set `GOPROXY` to `file://$(go env GOMODCACHE)/cache/download` so that `go get` skips querying the proxy.

Related: https://github.com/golang/go/issues/43646 (proposal for `GOPROXY=cache`)