### PR TITLE
Internal "go run"

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -135,19 +136,38 @@ func runTime(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-func gorun(srcFilename string, env []string, dir string, args ...string) error {
-	runArgs := make([]string, 0, 3+len(args))
-	runArgs = append(runArgs, "run", srcFilename, "--")
-	runArgs = append(runArgs, args...)
-	// log.Println(goCmd, runArgs)
+func gorun(srcFilename string, env []string, buildDir string, runDir string, args ...string) error {
+	exeDir, err := os.MkdirTemp("", "goeval*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(exeDir); err != nil {
+			log.Printf("RemoveAll(%q): %v", exeDir, err)
+		}
+	}()
 
-	cmd := exec.Command(goCmd, runArgs...)
-	cmd.Env = env
-	cmd.Dir = dir // In Go module mode we run from the temp module dir
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return run(cmd)
+	exePath := filepath.Join(exeDir, "goeval-run")
+	if runtime.GOOS == "windows" {
+		exePath += ".exe"
+	}
+
+	cmdBuild := exec.Command(goCmd, "build", "-o", exePath, srcFilename)
+	cmdBuild.Env = env
+	cmdBuild.Dir = buildDir
+	cmdBuild.Stdout = os.Stdout
+	cmdBuild.Stderr = os.Stderr
+	if err := run(cmdBuild); err != nil {
+		return fmt.Errorf("failed to build: %w", err)
+	}
+
+	cmdRun := exec.Command(exePath, args...)
+	cmdRun.Env = env
+	cmdRun.Dir = runDir // In Go module mode we run from the temp module dir
+	cmdRun.Stdin = os.Stdin
+	cmdRun.Stdout = os.Stdout
+	cmdRun.Stderr = os.Stderr
+	return run(cmdRun)
 }
 
 var goCmd = "go"
@@ -202,7 +222,7 @@ func flagAction(name string, a actionBits, usage string) {
 
 func _main() error {
 	imports := imports{
-		packages:   map[string]string{"  ": "os"},
+		packages:   map[string]string{},
 		onlySemVer: true,
 	}
 	flag.Var(&imports, "i", "* import package: [alias=]import-path\n* switch to Go module mode and import package: [alias=]import-path@version")
@@ -381,10 +401,6 @@ func _main() error {
 	}
 	src.WriteString("func main() {\n")
 	if action <= actionDump {
-		src.WriteString("os.Args[1] = os.Args[0]\nos.Args = os.Args[1:]\n")
-		if moduleMode {
-			fmt.Fprintf(&src, "_ = os.Chdir(%q)\n", origDir)
-		}
 		src.WriteString("//line :1\n")
 	}
 	src.WriteString(code)
@@ -410,7 +426,7 @@ func _main() error {
 			if err = f.Close(); err != nil {
 				return err
 			}
-			return gorun(srcFilename, env, dir, args...)
+			return gorun(srcFilename, env, dir, origDir, args...)
 		}
 	case actionPlay:
 		var cleanup func()

--- a/main_test.go
+++ b/main_test.go
@@ -42,14 +42,9 @@ func Example_dump() {
 	// Output:
 	// package main
 	//
-	// import (
-	//	"fmt"
-	//	"os"
-	// )
+	// import "fmt"
 	//
 	// func main() {
-	//	os.Args[1] = os.Args[0]
-	//	os.Args = os.Args[1:]
 	// //line :1
 	//	fmt.Println("OK")
 	// }


### PR DESCRIPTION
Replace the use of "go run" with an internal implementation.

Closes #9.