### PR TITLE
Refactor to return errors instead of log.Fatal for error management

### DIFF
--- a/main.go
+++ b/main.go
@@ -374,7 +374,7 @@ func _main() error {
 
 		var err error
 		if dir, err = os.MkdirTemp("", "goeval*"); err != nil {
-			log.Fatal(err)
+			return err
 		}
 		// Remove dir, dir/go.mod, dir/go.sum
 		// Ignore errors: this is a temp dir
@@ -384,12 +384,12 @@ func _main() error {
 
 		origDir, err = os.Getwd()
 		if err != nil {
-			log.Fatal("getwd:", err)
+			return fmt.Errorf("getwd: %w", err)
 		}
 
 		gomod := dir + "/go.mod"
 		if err := os.WriteFile(gomod, []byte("module "+moduleName+"\n"), 0600); err != nil {
-			log.Fatal("go.mod:", err)
+			return fmt.Errorf("go.mod: %w", err)
 		}
 
 		var gogetArgs []string
@@ -435,7 +435,7 @@ func _main() error {
 		cmd.Stderr = &stderr
 		if err = run(cmd); err != nil {
 			stderr.WriteTo(os.Stderr)
-			log.Fatal("go get failure:", err)
+			return fmt.Errorf("go get failure: %w", err)
 		}
 		// log.Println("go get OK.")
 	}
@@ -497,12 +497,14 @@ func _main() error {
 		srcFilename string
 		// tail is the action that will process srcFinal.
 		tail func() error
+
+		err error
 	)
 	switch action {
 	case actionRun, actionBuild:
 		f, err := os.CreateTemp(dir, "*.go")
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer f.Close()
 		defer os.Remove(f.Name())
@@ -517,18 +519,23 @@ func _main() error {
 		}
 	case actionPlay:
 		var cleanup func()
-		srcFinal, tail, cleanup = prepareSubPlay()
+		srcFinal, tail, cleanup, err = prepareSubPlay()
+		if err != nil {
+			return err
+		}
 		defer cleanup()
 	case actionShare:
 		var cleanup func()
-		srcFinal, tail, cleanup = prepareSubShare()
+		srcFinal, tail, cleanup, err = prepareSubShare()
+		if err != nil {
+			return err
+		}
 		defer cleanup()
 	default: // actionDump, actionDumpPlay
 		srcFinal = os.Stdout
 		tail = func() error { return nil }
 	}
 
-	var err error
 	switch goimports {
 	case "goimports":
 		var out []byte
@@ -578,7 +585,7 @@ func _main() error {
 	if moduleMode && action >= actionDump {
 		gomod, err := os.Open(dir + "/go.mod")
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		io.WriteString(srcFinal, "-- go.mod --\n")
 		defer gomod.Close()
@@ -588,7 +595,7 @@ func _main() error {
 		switch {
 		case errors.Is(err, os.ErrNotExist): // ignore
 		case err != nil:
-			log.Fatal(err)
+			return err
 		default:
 			io.WriteString(srcFinal, "-- go.sum --\n")
 			defer gosum.Close()

--- a/sub.go
+++ b/sub.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	_ "embed"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 )
@@ -41,22 +40,22 @@ var (
 )
 
 // prepareSubPlay prepare the source code for compilation and execution of sub/play/play.go.
-func prepareSubPlay() (stdin *bytes.Buffer, tail func() error, cleanup func()) {
+func prepareSubPlay() (stdin *bytes.Buffer, tail func() error, cleanup func(), err error) {
 	return prepareSub(playSubSource)
 }
 
 // prepareSubPlay prepare the source code for compilation and execution of sub/share/share.go.
-func prepareSubShare() (stdin *bytes.Buffer, tail func() error, cleanup func()) {
+func prepareSubShare() (stdin *bytes.Buffer, tail func() error, cleanup func(), err error) {
 	return prepareSub(shareSubSource)
 }
 
 // prepareSub prepares execution of a sub command via a "go run".
 // The returned stdin buffer may be filled with data.
 // cleanup must be called after cmd.Run() to clean the tempoary go source created.
-func prepareSub(appCode string) (stdin *bytes.Buffer, tail func() error, cleanup func()) {
+func prepareSub(appCode string) (stdin *bytes.Buffer, tail func() error, cleanup func(), err error) {
 	f, err := os.CreateTemp("", "*.go")
 	if err != nil {
-		log.Fatal(err)
+		return nil, nil, nil, err
 	}
 	defer f.Close()
 	fName := f.Name()
@@ -65,7 +64,8 @@ func prepareSub(appCode string) (stdin *bytes.Buffer, tail func() error, cleanup
 	}
 
 	if _, err := io.WriteString(f, appCode); err != nil {
-		log.Fatal(err)
+		cleanup()
+		return nil, nil, nil, err
 	}
 
 	// Prepare input that will be filled before executing the command

--- a/sub_offline.go
+++ b/sub_offline.go
@@ -36,10 +36,10 @@ func disabledFeature(string) error {
 	return errors.New(featureIsDisabled)
 }
 
-func prepareSubPlay() (*bytes.Buffer, func() error, func()) {
+func prepareSubPlay() (*bytes.Buffer, func() error, func(), error) {
 	panic("dead code in offline mode")
 }
 
-func prepareSubShare() (*bytes.Buffer, func() error, func()) {
+func prepareSubShare() (*bytes.Buffer, func() error, func(), error) {
 	panic("dead code in offline mode")
 }


### PR DESCRIPTION
Refactor the codebase to return errors instead of using `log.Fatal` to ensure resource cleanup via `defer`.

---
*PR created automatically by Jules for task [1608676116030109952](https://jules.google.com/task/1608676116030109952) started by @dolmen*