### PR TITLE
Deterministic import iteration in code generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,10 +24,12 @@ import (
 	"go/token"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -466,7 +468,8 @@ func _main() error {
 	}
 
 	src.WriteString("package main\n")
-	for alias, path := range imports.packages {
+	for _, alias := range slices.Sorted(maps.Keys(imports.packages)) {
+		path := imports.packages[alias]
 		if len(alias) > 2 && alias[1] == ' ' {
 			switch alias[0] {
 			case '.', '_':


### PR DESCRIPTION
Updated the code generation block in `main.go` that iterates over `imports.packages`. Instead of iterating directly over the map, which is non-deterministic, it now collects the aliases into a slice, sorts them using `slices.Sorted(maps.Keys(imports.packages))`, and then iterates over the sorted slice. This ensures deterministic output for import statements in the generated code.

---
*PR created automatically by Jules for task [2342462672152382801](https://jules.google.com/task/2342462672152382801) started by @dolmen*